### PR TITLE
Needed to modify the cylc suite template to add walltime for cheyenne.

### DIFF
--- a/src/cylc_template.py
+++ b/src/cylc_template.py
@@ -92,9 +92,8 @@ def create_cylc_input(graph, env, path):
         else:
             f.write('    [['+task+' ]]\n')
             f.write('        script = '+cr+'/'+commands[tool]+'\n')
-        f.write('        [[[job submission]]]\n'+
+        f.write('        [[[job]]]\n'+
                 '                method = '+env['batch_type']+'\n'+
-                '        [[[job]]]\n'+
                 '                execution time limit = PT12H\n'+
                 '        [[[directives]]]\n')
         if tool == 'timeseriesL':


### PR DESCRIPTION
This was needed to work with clc version 7.4.0.  This change will cause
suites running with an older version of cylc to break!